### PR TITLE
fix(MailLog): ordne den Spalten die korrekte Bezichnung zu

### DIFF
--- a/app/models/mail_archivist/action_mailer_hook.rb
+++ b/app/models/mail_archivist/action_mailer_hook.rb
@@ -1,11 +1,11 @@
 module MailArchivist
   class ActionMailerHook
     def self.delivered_email(message)
-      MailArchivist::MailLog.create(to: (message.to||[]).join(','),
-                      cc: (message.to||[]).join(','),
-                      from: (message.to||[]).join(','),
-                      subject:  message.subject,
-                      body:  (message.text_part || message.html_part || message.body).to_s)
+      MailArchivist::MailLog.create(to: (message.to || []).join(','),
+                                    cc: (message.cc || []).join(','),
+                                    from: (message.from || []).join(','),
+                                    subject: message.subject,
+                                    body: (message.text_part || message.html_part || message.body).to_s)
     end
   end
 end

--- a/lib/mail_archivist/version.rb
+++ b/lib/mail_archivist/version.rb
@@ -1,3 +1,3 @@
 module MailArchivist
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end


### PR DESCRIPTION
Hier wird immer die Spalte to zugeordnet. Das ist so vermutlich nicht richtig.